### PR TITLE
fix: Update useFetchRequest params

### DIFF
--- a/client/src/components/interests-form.tsx
+++ b/client/src/components/interests-form.tsx
@@ -16,7 +16,7 @@ import { Button } from "./ui/button";
 import { InterestFormProps, SingleInterestType } from "@/typings/types";
 
 const InterestForm = ({ interests, setInterests }: InterestFormProps) => {
-  const { data: topics } = useFetchRequest("topics", "/api/topics");
+  const { data: topics } = useFetchRequest(["topics"], "/api/topics");
   const [newInterest, setNewInterest] = useState<SingleInterestType | null>(
     null
   );

--- a/client/src/components/skills-form.tsx
+++ b/client/src/components/skills-form.tsx
@@ -10,7 +10,10 @@ import useFetchRequest from "@/hooks/useFetchRequest";
 import { SingleSkillType, SkillsFormProps } from "@/typings/types";
 
 const SkillsForm = ({ skills, setSkills }: SkillsFormProps) => {
-  const { data: categories } = useFetchRequest("categories", "/api/categories");
+  const { data: categories } = useFetchRequest(
+    ["categories"],
+    "/api/categories"
+  );
   const [availableSkills, setAvailableSkills] = useState<SingleSkillType[]>([]);
   const [skillSearchQuery, setSkillSearchQuery] = useState("");
   const [isSkillsInputFocused, setIsSkillsInputFocused] = useState(false);


### PR DESCRIPTION
Changes to `client/src/components/interests-form.tsx`:

* Modified the `useFetchRequest` hook call to pass the query key as an array instead of a string.

Changes to `client/src/components/skills-form.tsx`:

* Updated the `useFetchRequest` hook call to pass the query key as an array instead of a string.