### PR TITLE
feat: Add fallback image URL logic in post schema for empty or undefined values

### DIFF
--- a/api/src/models/postModel.ts
+++ b/api/src/models/postModel.ts
@@ -17,6 +17,12 @@ const postSchema = new Schema<PostInterface>(
       public_id: String,
       default:
         "https://firebasestorage.googleapis.com/v0/b/personal-blog-e0f8c.appspot.com/o/images%2Ffallback-featured-image.webp?alt=media&token=44970380-079b-4d03-80e8-9b322a365e1c",
+      set: (value: string | null | undefined) => {
+        if (!value || value.trim() === "") {
+          return "https://firebasestorage.googleapis.com/v0/b/personal-blog-e0f8c.appspot.com/o/images%2Ffallback-featured-image.webp?alt=media&token=44970380-079b-4d03-80e8-9b322a365e1c";
+        }
+        return value;
+      },
     },
     likes: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
     bookmarks: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],


### PR DESCRIPTION
* [`api/src/models/postModel.ts`](diffhunk://#diff-a8aab2fdbe590852b42107e3e44c73a9067b71accf33ee70a3524254b241ce4bR20-R25): Added a setter function for the `public_id` field to provide a default URL if the value is null, undefined, or an empty string.