### PR TITLE
fix: Sort blog posts by creation date before rendering

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -73,15 +73,19 @@ export default function Home() {
 
   const blogCards = useMemo(() => {
     if (Array.isArray(posts?.data))
-      return posts?.data?.map(
-        (post: PostType, index: { toString: () => any }) => (
+      return posts?.data
+        ?.sort(
+          (a: PostType, b: PostType) =>
+            new Date(String(b.createdAt ?? new Date())).getTime() -
+            new Date(String(a.createdAt ?? new Date())).getTime()
+        )
+        .map((post: PostType, index: { toString: () => any }) => (
           <BlogPostCard
             key={post?._id.toString() + index.toString()}
             post={post}
             slug={post?.slug as string}
           />
-        )
-      );
+        ));
   }, [posts]);
 
   return (


### PR DESCRIPTION
* [`client/src/app/page.tsx`](diffhunk://#diff-ca592de89ef2b9d78e1cdb3a81dfcabe1974035a52d6e85658c31848be0cd79cL76-R88): Added sorting logic to the `blogCards` useMemo hook to order posts by their `createdAt` date in descending order.