### PR TITLE
Feat/edit post loading skeleton

### DIFF
--- a/client/src/app/edit-post/[slug]/page.tsx
+++ b/client/src/app/edit-post/[slug]/page.tsx
@@ -5,13 +5,13 @@ import useFetchPost from "@/hooks/useFetchPost";
 
 const EditPostPage = ({ params }: { params: { slug: string } }) => {
   const slug = decodeURI(params.slug);
-  const { data, isLoading, isFetching } = useFetchPost(slug);
+  const { data, isPending } = useFetchPost(slug);
 
   const post = data?.data;
   return (
     <div className="pt-24 bg-background min-h-screen">
       <div className="bg-background">
-        <BlogEditor initialPost={post} slug={slug} />
+        <BlogEditor initialPost={post} slug={slug} isPostLoading={isPending} />
       </div>
     </div>
   );

--- a/client/src/components/blog-editor.tsx
+++ b/client/src/components/blog-editor.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { FC, FormEvent, useEffect, useState } from "react";
+import React, { FC, FormEvent, useEffect } from "react";
 import "react-quill/dist/quill.snow.css";
 import { Input } from "./ui/input";
 import FeatureImage from "./feature-image";
@@ -7,20 +7,20 @@ import { useBlogEditor } from "@/hooks/useBlogEditor";
 import Layout from "@/app/new/layout";
 import Categories from "./categories";
 import Tags from "./tags";
-import { BouncingCircles } from "./icons";
 import dynamic from "next/dynamic";
 import { BlogEditorProps } from "@/typings/interfaces";
+import QuillLoadingSkeleton from "./quill-loading-skeleton";
 
 const Editor = dynamic(() => import("./editor"), {
   ssr: false,
+  loading: () => <QuillLoadingSkeleton />,
 });
 
 const BlogEditor: FC<BlogEditorProps> = ({
   initialPost = null,
   slug = null,
+  isPostLoading = false,
 }) => {
-  const [isEditorLoaded, setIsEditorLoaded] = useState(false);
-
   const handleSave = (e: FormEvent) => {
     handleSubmit(e);
   };
@@ -45,10 +45,6 @@ const BlogEditor: FC<BlogEditorProps> = ({
   } = useBlogEditor({ initialPost, slug });
 
   useEffect(() => {
-    if (Editor) setIsEditorLoaded(true);
-  }, []);
-
-  useEffect(() => {
     if (initialPost) {
       setTitle(initialPost.title || "");
       setContent(initialPost.content || "");
@@ -60,42 +56,38 @@ const BlogEditor: FC<BlogEditorProps> = ({
 
   return (
     <Layout onSave={handleSave}>
-      {!isEditorLoaded ? (
-        <div className="flex items-center justify-center min-h-screen">
-          <BouncingCircles />
-        </div>
-      ) : (
-        <div className="flex-column md:flex">
-          <div className="mb-20 xs:mb-4 md:w-3/4 p-4">
-            <form onSubmit={handleSubmit}>
-              <div className="mb-4">
+      <div className="flex-column md:flex">
+        <div className={`mb-20 ${!isPostLoading && "p-4"} xs:mb-4 md:w-3/4  `}>
+          <form onSubmit={handleSubmit}>
+            <div className="mb-4">
+              {!isPostLoading && (
                 <Input
                   id="title"
                   value={title}
                   onChange={handleTitleChange}
                   placeholder="Enter blog title"
                 />
-              </div>
-              <div className="mb-4">
-                <Editor
-                  value={content || (initialPost?.content as string)}
-                  onChange={handleContentChange}
-                  handleImageUpload={handleImageUpload}
-                />
-              </div>
-            </form>
-          </div>
-          <div className="[&>*:nth-child(even)]:my-8 md:w-1/4 p-4">
-            <FeatureImage
-              imageUrl={featuredImage}
-              temporaryFeatureImage={temporaryFeatureImage}
-              onUpload={handleFeatureImagePick}
-            />
-            <Categories categories={categories} setCategories={setCategories} />
-            <Tags tags={tags} setTags={setTags} />
-          </div>
+              )}
+            </div>
+            <div className="mb-4">
+              <Editor
+                value={content || (initialPost?.content as string)}
+                onChange={handleContentChange}
+                handleImageUpload={handleImageUpload}
+              />
+            </div>
+          </form>
         </div>
-      )}
+        <div className="[&>*:nth-child(even)]:my-8 md:w-1/4 p-4">
+          <FeatureImage
+            imageUrl={featuredImage}
+            temporaryFeatureImage={temporaryFeatureImage}
+            onUpload={handleFeatureImagePick}
+          />
+          <Categories categories={categories} setCategories={setCategories} />
+          <Tags tags={tags} setTags={setTags} />
+        </div>
+      </div>
     </Layout>
   );
 };

--- a/client/src/components/quill-loading-skeleton.tsx
+++ b/client/src/components/quill-loading-skeleton.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function QuillLoadingSkeleton() {
+  return (
+    <div className="w-full h-screen rounded-lg bg-background px-4">
+      {/* Header/Title area */}
+      <div className="border p-2 rounded-md mb-4 w-full">
+        <Skeleton className="h-6 w-3/4" />
+      </div>
+      <div className="border py-2 px-4  rounded-md">
+        {/* Toolbar */}
+        <div className="flex items-center border-b py-2 md:space-x-1 flex-wrap gap-y-2 gap-x-1 ">
+          <Skeleton className="h-8 w-8" /> {/* Undo */}
+          <Skeleton className="h-8 w-8" /> {/* Redo */}
+          <div className="!mx-2 h-4 w-px bg-border" /> {/* Divider */}
+          <Skeleton className="h-8 w-16" /> {/* Header dropdown */}
+          <div className="!mx-2 h-4 w-px bg-border" /> {/* Divider */}
+          <div className="flex space-x-1">
+            <Skeleton className="h-8 w-8" /> {/* Bold */}
+            <Skeleton className="h-8 w-8" /> {/* Italic */}
+            <Skeleton className="h-8 w-8" /> {/* Underline */}
+          </div>
+          <div className="m!x-2 h-4 w-px bg-border" /> {/* Divider */}
+          <div className="flex space-x-1">
+            <Skeleton className="h-8 w-8" /> {/* Align left */}
+            <Skeleton className="h-8 w-8" /> {/* Align center */}
+            <Skeleton className="h-8 w-8" /> {/* Align right */}
+          </div>
+          <div className="!mx-2 h-4 w-px bg-border" /> {/* Divider */}
+          <Skeleton className="h-8 w-24" /> {/* Font dropdown */}
+        </div>
+
+        {/* Content area */}
+        <div className="space-y-2 py-4">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-[90%]" />
+          <Skeleton className="h-4 w-[95%]" />
+          <Skeleton className="h-4 w-[85%] !mb-4" />
+          <Skeleton className="min-h-36 sm:min-h-56 w-[65%] !mb-4" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-[90%]" />
+          <Skeleton className="h-4 w-[95%]" />
+          <Skeleton className="h-4 w-[85%]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/useFetchPost.ts
+++ b/client/src/hooks/useFetchPost.ts
@@ -1,12 +1,12 @@
 import useFetchRequest from "./useFetchRequest";
 
 const useFetchPost = (slug: string) => {
-  const { data, error, isLoading, isFetching } = useFetchRequest(
+  const { data, error, isLoading, isFetching, isPending } = useFetchRequest(
     ["post", slug],
     `/api/posts/${slug}`
   );
 
-  return { data, error, isLoading, isFetching };
+  return { data, error, isLoading, isFetching, isPending };
 };
 
 export default useFetchPost;

--- a/client/src/typings/interfaces/index.ts
+++ b/client/src/typings/interfaces/index.ts
@@ -34,6 +34,7 @@ export interface BlogEditorProps {
     tags?: string[];
   } | null;
   slug?: string;
+  isPostLoading?: boolean;
 }
 
 export interface InitialPost {


### PR DESCRIPTION
Improvements to loading experience:

* [`client/src/components/quill-loading-skeleton.tsx`](diffhunk://#diff-4a9a26649acbee9011674668c59af192b28aa94f5680d2d0918753e67d354440R1-R48): Added a new `QuillLoadingSkeleton` component to display a loading skeleton while the editor is loading.

Refactoring blog editor component:

* [`client/src/components/blog-editor.tsx`](diffhunk://#diff-79c762b911a6575b4fbe993d6567deb829f98048d4063b0ed99d767278bee103L2-L23): Modified the `BlogEditor` component to use the new `QuillLoadingSkeleton` and handle the `isPostLoading` prop to conditionally render the editor and input fields. Removed the `BouncingCircles` loading indicator and the `isEditorLoaded` state. [[1]](diffhunk://#diff-79c762b911a6575b4fbe993d6567deb829f98048d4063b0ed99d767278bee103L2-L23) [[2]](diffhunk://#diff-79c762b911a6575b4fbe993d6567deb829f98048d4063b0ed99d767278bee103L47-L50) [[3]](diffhunk://#diff-79c762b911a6575b4fbe993d6567deb829f98048d4063b0ed99d767278bee103L63-R70) [[4]](diffhunk://#diff-79c762b911a6575b4fbe993d6567deb829f98048d4063b0ed99d767278bee103L98)

Updating hooks:

* [`client/src/hooks/useFetchPost.ts`](diffhunk://#diff-8ef55ff312e3dcc3b4ea9b567242b726570d0a58c8baf6fbbd9e648a2a3ffb4fL4-R9): Updated the `useFetchPost` hook to include a new `isPending` state returned from `useFetchRequest`.

Updating type definitions:

* [`client/src/typings/interfaces/index.ts`](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392R37): Added a new `isPostLoading` property to the `BlogEditorProps` interface.

Updating page component:

* `client/src/app/edit-post/[slug]/page.tsx`: Updated the `EditPostPage` component to use the new `isPending` state from `useFetchPost` and pass it to the `BlogEditor` component as `isPostLoading`. ([client/src/app/edit-post/[slug]/page.tsxL8-R14](diffhunk://#diff-e98346c711081cb5f228f5408767b4be1faf31113a3ea140bf61656779627130L8-R14))