### PR TITLE
Quickfix/category types

### DIFF
--- a/client/src/components/categories.tsx
+++ b/client/src/components/categories.tsx
@@ -83,7 +83,7 @@ const Categories = ({
     });
 
     setCategories((prevCategories) =>
-      prevCategories.filter((c) => c !== category._id)
+      prevCategories.filter((c) => c.toString() !== category._id.toString())
     );
   };
 
@@ -101,7 +101,7 @@ const Categories = ({
         (availableCategory) => availableCategory._id !== category._id
       )
     );
-    setCategories((prevCategories) => [...prevCategories, category._id]);
+    setCategories((prevCategories) => [...prevCategories, category]);
   };
 
   const showMoreCategories = () => {

--- a/client/src/typings/interfaces/index.ts
+++ b/client/src/typings/interfaces/index.ts
@@ -30,7 +30,7 @@ export interface BlogEditorProps {
     title: string;
     content: string;
     featuredImage: string | null;
-    categories?: ObjectId[];
+    categories?: CategoryInterface[];
     tags?: string[];
   } | null;
   slug?: string;
@@ -42,7 +42,7 @@ export interface InitialPost {
   title: string;
   content: string;
   featuredImage: string | null;
-  categories?: ObjectId[];
+  categories?: CategoryInterface[];
   tags?: string[];
 }
 export interface UseBlogEditorProps {

--- a/client/src/typings/types/index.ts
+++ b/client/src/typings/types/index.ts
@@ -4,7 +4,7 @@ import { PostInterface } from "../../../../api/src/typings/models/post";
 import { UserInterface } from "../../../../api/src/typings/models/user";
 import { TopicInterface } from "../../../../api/src/typings/models/topic";
 import { CategoryInterface } from "../../../../api/src/typings/models/category";
-import { Date, ObjectId } from "mongoose";
+import { Date } from "mongoose";
 import { CommentInterface } from "../interfaces";
 import { QueryObserverResult, RefetchOptions } from "@tanstack/react-query";
 import { Dispatch, SetStateAction } from "react";
@@ -136,8 +136,8 @@ export type IconProps = {
 };
 
 export type CategoriesProps = {
-  setCategories: Dispatch<SetStateAction<ObjectId[]>>;
-  categories: ObjectId[] | [];
+  setCategories: Dispatch<SetStateAction<CategoryInterface[]>>;
+  categories: CategoryInterface[] | [];
 };
 
 export type TagsProps = {


### PR DESCRIPTION
Changes to category handling:

* [`client/src/components/categories.tsx`](diffhunk://#diff-880f22706e5f44942df773fdb0861523e22592aad7589ab70124f0a3f59264b0L86-R86): Updated the filtering logic to ensure category IDs are compared as strings and modified the state update to store entire category objects instead of just their IDs. [[1]](diffhunk://#diff-880f22706e5f44942df773fdb0861523e22592aad7589ab70124f0a3f59264b0L86-R86) [[2]](diffhunk://#diff-880f22706e5f44942df773fdb0861523e22592aad7589ab70124f0a3f59264b0L104-R104)

Updates to type definitions:

* [`client/src/typings/interfaces/index.ts`](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L33-R33): Changed the `categories` field in `BlogEditorProps` and `InitialPost` interfaces to use `CategoryInterface[]` instead of `ObjectId[]`. [[1]](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L33-R33) [[2]](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L45-R45)
* [`client/src/typings/types/index.ts`](diffhunk://#diff-2b6d5084fa23e6552408822b5b99be444402d8def24325dfd5bc786ff85f6384L7-R7): Updated the `CategoriesProps` type to use `CategoryInterface[]` and removed the import of `ObjectId` from Mongoose. [[1]](diffhunk://#diff-2b6d5084fa23e6552408822b5b99be444402d8def24325dfd5bc786ff85f6384L7-R7) [[2]](diffhunk://#diff-2b6d5084fa23e6552408822b5b99be444402d8def24325dfd5bc786ff85f6384L139-R140)