### PR TITLE
fix: Replace BadRequest with ApiError in authOptions for improved error handling

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -2,8 +2,8 @@ import GithubProvider from "next-auth/providers/github";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import type { NextAuthOptions } from "next-auth";
-import { BadRequest } from "../../../api/src/errors/bad-request";
 import axios from "axios";
+import { ApiError } from "./errors/ApiError";
 const baseUrl = `${process.env.NEXT_PUBLIC_FRONTEND_API_ENDPOINT}/api`;
 
 export const authOptions: NextAuthOptions = {
@@ -25,7 +25,7 @@ export const authOptions: NextAuthOptions = {
       async authorize(credentials) {
         try {
           if (!credentials?.email || !credentials?.password) {
-            throw new BadRequest("Email and password are required");
+            throw ApiError.BadRequest("Email and password are required");
           }
           const res = await axios.post(`${baseUrl}/auth/login`, {
             email: credentials.email,

--- a/client/src/lib/errors/ApiError.ts
+++ b/client/src/lib/errors/ApiError.ts
@@ -1,0 +1,25 @@
+export class ApiError extends Error {
+  public statusCode: number;
+
+  constructor(message: string, statusCode: number = 400) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+  }
+
+  static BadRequest(message: string) {
+    return new ApiError(message, 400);
+  }
+
+  static Unauthorized(message: string) {
+    return new ApiError(message, 401);
+  }
+
+  static NotFound(message: string) {
+    return new ApiError(message, 404);
+  }
+
+  static InternalServer(message: string = "Internal server error") {
+    return new ApiError(message, 500);
+  }
+}


### PR DESCRIPTION
Key changes:

### Error Handling Improvements:
* [`client/src/lib/auth.ts`](diffhunk://#diff-f91399a6444b3e4cd1811221c9e153e17b5ea5f01e1386a517513fd6ccd0c7bbL5-R6): Replaced the `BadRequest` error with the new `ApiError` class for better error handling and consistency. [[1]](diffhunk://#diff-f91399a6444b3e4cd1811221c9e153e17b5ea5f01e1386a517513fd6ccd0c7bbL5-R6) [[2]](diffhunk://#diff-f91399a6444b3e4cd1811221c9e153e17b5ea5f01e1386a517513fd6ccd0c7bbL28-R28)

### New Error Class:
* [`client/src/lib/errors/ApiError.ts`](diffhunk://#diff-e96ccbb9c94d8a30b7d92a9e393393c8d8d6d9627cc2bd51c757cc3b7f7c91baR1-R25): Added a new `ApiError` class with methods for different types of HTTP errors (`BadRequest`, `Unauthorized`, `NotFound`, and `InternalServer`).