### PR TITLE
Feat/front end types

### DIFF
--- a/client/src/components/categories.tsx
+++ b/client/src/components/categories.tsx
@@ -7,7 +7,6 @@ import useFetchRequest from "@/hooks/useFetchRequest";
 import { Skeleton } from "./ui/skeleton";
 import { XIcon } from "./icons";
 import { CategoriesProps } from "@/typings/types";
-import { ObjectId } from "mongoose";
 
 const Categories = ({
   setCategories,
@@ -51,7 +50,7 @@ const Categories = ({
         .map((category) => {
           return fetchedCategories.data.find(
             (cat: CategoryInterface) =>
-              cat._id === (category as unknown as ObjectId)
+              cat._id.toString() === category.toString()
           );
         })
         .filter(Boolean) as CategoryInterface[];

--- a/client/src/hooks/useBlogEditor.ts
+++ b/client/src/hooks/useBlogEditor.ts
@@ -22,7 +22,6 @@ import usePostRequest from "./usePostRequest";
 import { useQueryClient } from "@tanstack/react-query";
 import DOMPurify from "dompurify";
 import { UpdatePostPayload, UserType } from "@/typings/types";
-import mongoose, { ObjectId } from "mongoose";
 import usePatchRequest from "./usePatchRequest";
 import { arraysEqual } from "@/utils/formats";
 
@@ -306,7 +305,7 @@ export const useBlogEditor = ({ initialPost, slug }: UseBlogEditorProps) => {
         if (Object.keys(changes).length > 0) {
           updatePostMutate({
             ...changes,
-            _id: initialPost._id as unknown as mongoose.Types.ObjectId,
+            _id: initialPost?._id?.toString(),
           });
         } else {
           toast({

--- a/client/src/hooks/useDeleteComment.ts
+++ b/client/src/hooks/useDeleteComment.ts
@@ -1,9 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ui/use-toast";
 import axios from "axios";
-import { CommentInterface, ReplyInterface } from "@/typings/interfaces";
+import {
+  CommentInterface,
+  PostInterface,
+  ReplyInterface,
+} from "@/typings/interfaces";
 import { PostFetchType, PostType } from "@/typings/types";
-import { PostInterface } from "../../../api/src/typings/models/post";
 
 const useDeleteComment = (post?: PostType) => {
   const { toast } = useToast();

--- a/client/src/hooks/useInteractions.ts
+++ b/client/src/hooks/useInteractions.ts
@@ -2,11 +2,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import usePutRequest from "./usePutRequest";
 import { useToast } from "@/components/ui/use-toast";
 import { CommentFetchType, PostFetchType, PostType } from "@/typings/types";
-import { ObjectId } from "mongoose";
-import { PostInterface } from "../../../api/src/typings/models/post";
 import usePostRequest from "./usePostRequest";
 import { MouseEvent, useEffect, useRef, useState } from "react";
-import { CommentInterface, ReplyInterface } from "@/typings/interfaces";
+import {
+  CommentInterface,
+  PostInterface,
+  ReplyInterface,
+} from "@/typings/interfaces";
 import { getSession } from "next-auth/react";
 
 export const useInteractions = (
@@ -81,7 +83,7 @@ export const useInteractions = (
           data: postsData.data.map((post: PostInterface) => {
             if (post._id.toString() === variables.postId.toString()) {
               const userId = queryClient.getQueryData<{
-                data: { _id: ObjectId };
+                data: { _id: string };
               }>(["currentUser"])?.data._id;
               const userIdString = userId?.toString();
               const isLiked = post.likes?.some(
@@ -147,7 +149,7 @@ export const useInteractions = (
           data: oldPosts.data.map((post: PostInterface) => {
             if (post._id.toString() === postId.toString()) {
               const userId = queryClient.getQueryData<{
-                data: { _id: ObjectId };
+                data: { _id: string };
               }>(["currentUser"])?.data._id;
               const userIdString = userId?.toString();
               const isLiked = post.likes?.some(
@@ -211,7 +213,7 @@ export const useInteractions = (
           data: postsData.data.map((post: PostInterface) => {
             if (post._id.toString() === variables.postId.toString()) {
               const userId = queryClient.getQueryData<{
-                data: { _id: ObjectId };
+                data: { _id: string };
               }>(["currentUser"])?.data._id;
               const userIdString = userId?.toString();
               const isBookmarked = post.bookmarks?.some(
@@ -277,7 +279,7 @@ export const useInteractions = (
           data: oldPosts.data.map((post: PostInterface) => {
             if (post._id.toString() === postId.toString()) {
               const userId = queryClient.getQueryData<{
-                data: { _id: ObjectId };
+                data: { _id: string };
               }>(["currentUser"])?.data._id;
               const userIdString = userId?.toString();
               const isBookmarked = post.likes?.some(

--- a/client/src/typings/interfaces/index.ts
+++ b/client/src/typings/interfaces/index.ts
@@ -1,8 +1,79 @@
 import { FormEvent, HTMLAttributes, MouseEvent, ReactNode } from "react";
-import { ObjectId } from "mongoose";
 import { AxiosError } from "axios";
 import { LucideIcon } from "lucide-react";
 import { PostType, UserType } from "../types";
+
+export interface BaseDocument {
+  _id: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CategoryInterface extends BaseDocument {
+  name: String;
+  postedBy: string;
+  slug: String;
+  topic: string;
+  usageCount: Number;
+}
+
+export interface SocialMediaProfilesInterface {
+  x?: string;
+  instagram?: string;
+  github?: string;
+  linkedIn?: string;
+  dribble?: string;
+}
+
+export interface PostInterface extends BaseDocument {
+  _id: string;
+  title: string;
+  content: string;
+  slug: string;
+  postedBy: string;
+  featuredImage?: string;
+  likes?: string[];
+  bookmarks?: string[];
+  tags?: string[];
+  categories?: CategoryInterface[];
+  visits?: number;
+  comments?: string[];
+  status: "draft" | "published" | "unpublished";
+}
+
+export interface TopicInterface extends BaseDocument {
+  name: String;
+  postedBy: string;
+  description: String;
+}
+
+export interface UserInterface extends BaseDocument {
+  firstName: String;
+  lastName: String;
+  email: String;
+  password: String;
+  username: String;
+  website?: String;
+  bio?: String;
+  title?: String;
+  role: String;
+  verificationToken?: String;
+  verified?: Boolean;
+  verifiedAt?: Date;
+  accessToken: String | null;
+  passwordVerificationToken: String | null;
+  passwordTokenExpirationDate: Date | null;
+  bookmarks?: string[];
+  likes?: string[];
+  avatar?: String;
+  provider: String;
+  topicsOfInterest?: TopicInterface[];
+  technologies?: CategoryInterface[];
+  socialMediaProfiles?: SocialMediaProfilesInterface;
+  isOnboarded: Boolean;
+  following?: string[];
+  followers?: string[];
+}
 
 export interface CustomBadgeProps extends HTMLAttributes<HTMLDivElement> {
   value: string;
@@ -38,7 +109,7 @@ export interface BlogEditorProps {
 }
 
 export interface InitialPost {
-  _id?: ObjectId;
+  _id?: string;
   title: string;
   content: string;
   featuredImage: string | null;
@@ -57,40 +128,29 @@ export interface FeatureImageProps {
 }
 
 export interface CommentInterface {
-  _id: ObjectId;
-  postedBy: ObjectId;
-  post: ObjectId;
-  parentId?: ObjectId;
+  _id: string;
+  postedBy: string;
+  post: string;
+  parentId?: string;
   content: string;
   replies: string[];
-  likes: ObjectId[];
+  likes: string[];
   createdAt: Date;
   updatedAt: Date;
   isReply: boolean;
 }
 
 export interface ReplyInterface {
-  _id: ObjectId;
-  postedBy: ObjectId;
-  post: ObjectId;
+  _id: string;
+  postedBy: string;
+  post: string;
   content: string;
   parentId: string;
   replies: string[];
-  likes: ObjectId[];
+  likes: string[];
   createdAt: Date;
   updatedAt: Date;
   isReply: boolean;
-}
-
-export interface CategoryInterface {
-  _id: ObjectId;
-  name: String;
-  postedBy: ObjectId;
-  slug: String;
-  topic: ObjectId;
-  createdAt: Date;
-  updatedAt: Date;
-  usageCount: Number;
 }
 
 export interface MutationContext<TData> {
@@ -170,7 +230,7 @@ export interface SocialMediaConfig {
 }
 
 export interface AuthorPanelProps {
-  _id: ObjectId;
+  _id: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/client/src/typings/types/index.ts
+++ b/client/src/typings/types/index.ts
@@ -1,11 +1,12 @@
 import { BuiltInProviderType } from "next-auth/providers/index";
 import { ClientSafeProvider, LiteralUnion } from "next-auth/react";
-import { PostInterface } from "../../../../api/src/typings/models/post";
-import { UserInterface } from "../../../../api/src/typings/models/user";
-import { TopicInterface } from "../../../../api/src/typings/models/topic";
-import { CategoryInterface } from "../../../../api/src/typings/models/category";
-import { Date } from "mongoose";
-import { CommentInterface } from "../interfaces";
+import {
+  CategoryInterface,
+  PostInterface,
+  TopicInterface,
+  UserInterface,
+} from "../interfaces";
+import { CommentInterface, SocialMediaProfilesInterface } from "../interfaces";
 import { QueryObserverResult, RefetchOptions } from "@tanstack/react-query";
 import { Dispatch, SetStateAction } from "react";
 
@@ -30,16 +31,8 @@ export type UsePostRequestType = {
 export type ExtractImagesFromContentType = (content: string) => string[];
 export type DeleteImageFromFirebaseType = (imageUrl: string) => Promise<void>;
 
-export interface SocialMediaProfiles {
-  x?: string;
-  instagram?: string;
-  github?: string;
-  linkedIn?: string;
-  dribble?: string;
-}
-
 export type UserType = Omit<UserInterface, "socialMediaProfiles"> & {
-  socialMediaProfiles: SocialMediaProfiles;
+  socialMediaProfiles: SocialMediaProfilesInterface;
 };
 
 export type PostType = Omit<PostInterface, "postedBy" | "comments"> & {


### PR DESCRIPTION
### Refactoring to Remove `ObjectId`:

* [`client/src/components/categories.tsx`](diffhunk://#diff-880f22706e5f44942df773fdb0861523e22592aad7589ab70124f0a3f59264b0L54-R53): Updated the comparison logic for category IDs to use `string` instead of `ObjectId`.
* [`client/src/hooks/useBlogEditor.ts`](diffhunk://#diff-ac2e3080befdf8d28465d9b92ae289afd25c2109009a99038e913507f87c7305L309-R308): Changed the `_id` field in the `updatePostMutate` function to use `string`.
* [`client/src/hooks/useInteractions.ts`](diffhunk://#diff-96cc5f34744e8283b911e3fc91a765ad944940919cd86870b1b0d03c3f448a26L84-R86): Updated multiple instances of user and post ID comparisons to use `string` instead of `ObjectId`. [[1]](diffhunk://#diff-96cc5f34744e8283b911e3fc91a765ad944940919cd86870b1b0d03c3f448a26L84-R86) [[2]](diffhunk://#diff-96cc5f34744e8283b911e3fc91a765ad944940919cd86870b1b0d03c3f448a26L150-R152) [[3]](diffhunk://#diff-96cc5f34744e8283b911e3fc91a765ad944940919cd86870b1b0d03c3f448a26L214-R216) [[4]](diffhunk://#diff-96cc5f34744e8283b911e3fc91a765ad944940919cd86870b1b0d03c3f448a26L280-R282)

### Interface Updates:

* [`client/src/typings/interfaces/index.ts`](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L2-R77): Added new interfaces for `BaseDocument`, `CategoryInterface`, `SocialMediaProfilesInterface`, `PostInterface`, `TopicInterface`, and `UserInterface` to use `string` for IDs and other fields.
* [`client/src/typings/interfaces/index.ts`](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L60-L95): Updated existing interfaces such as `CommentInterface`, `ReplyInterface`, and `AuthorPanelProps` to use `string` for IDs. [[1]](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L60-L95) [[2]](diffhunk://#diff-6e4fff3049aa1b92159c65f154e1ada816afde5d9c52975e50351ee67e31f392L173-R233)

### Import Cleanups:

* [`client/src/components/categories.tsx`](diffhunk://#diff-880f22706e5f44942df773fdb0861523e22592aad7589ab70124f0a3f59264b0L10): Removed the unused import of `ObjectId` from `mongoose`.
* [`client/src/hooks/useBlogEditor.ts`](diffhunk://#diff-ac2e3080befdf8d28465d9b92ae289afd25c2109009a99038e913507f87c7305L25): Removed the unused import of `ObjectId` from `mongoose`.
* [`client/src/hooks/useDeleteComment.ts`](diffhunk://#diff-6c755387a786151a5201392093a1d4888fa955a1e98a7c0e3891efe9b5ef1e9bL4-L6): Cleaned up imports by removing the `PostInterface` import from an incorrect path and adding it from the correct one.
* [`client/src/hooks/useInteractions.ts`](diffhunk://#diff-96cc5f34744e8283b911e3fc91a765ad944940919cd86870b1b0d03c3f448a26L5-R11): Removed the unused import of `ObjectId` and `PostInterface` from incorrect paths and added them from the correct one.

### Type Adjustments:

* [`client/src/typings/types/index.ts`](diffhunk://#diff-2b6d5084fa23e6552408822b5b99be444402d8def24325dfd5bc786ff85f6384L33-R35): Updated `UserType` to use `SocialMediaProfilesInterface` instead of `SocialMediaProfiles`.
* [`client/src/typings/types/index.ts`](diffhunk://#diff-2b6d5084fa23e6552408822b5b99be444402d8def24325dfd5bc786ff85f6384L3-R9): Cleaned up imports by removing the unused `ObjectId` and `Date` from `mongoose`.