### PR TITLE
Fix/protected routes

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -22,6 +22,16 @@ export async function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
+  if (pathname === "/auth") {
+    if (token) {
+      const dashboardUrl = new URL("/dashboard", request.nextUrl.origin);
+      return NextResponse.redirect(dashboardUrl.toString());
+    } else {
+      const loginUrl = new URL("/login", request.nextUrl.origin);
+      return NextResponse.redirect(loginUrl.toString());
+    }
+  }
+
   const isProtectedRoute =
     protectedRoutes.some((route) => pathname.startsWith(route)) ||
     pathname.startsWith("/edit-post/");

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -45,6 +45,15 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  if (
+    pathname === "/blog" ||
+    pathname === "/blogs" ||
+    pathname === "/category"
+  ) {
+    const homeUrl = new URL("/", request.nextUrl.origin);
+    return NextResponse.redirect(homeUrl.toString());
+  }
+
   const isProtectedRoute =
     protectedRoutes.some((route) => pathname.startsWith(route)) ||
     pathname.startsWith("/edit-post/");

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -48,6 +48,7 @@ export async function middleware(request: NextRequest) {
   if (
     pathname === "/blog" ||
     pathname === "/blogs" ||
+    pathname === "/api" ||
     pathname === "/category"
   ) {
     const homeUrl = new URL("/", request.nextUrl.origin);

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -32,6 +32,19 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  if (pathname === "/users" || pathname === "/user") {
+    if (token) {
+      const userProfileUrl = new URL(
+        `/users/${token.sub}`,
+        request.nextUrl.origin
+      );
+      return NextResponse.redirect(userProfileUrl.toString());
+    } else {
+      const loginUrl = new URL("/login", request.nextUrl.origin);
+      return NextResponse.redirect(loginUrl.toString());
+    }
+  }
+
   const isProtectedRoute =
     protectedRoutes.some((route) => pathname.startsWith(route)) ||
     pathname.startsWith("/edit-post/");

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -8,6 +8,8 @@ const protectedRoutes = [
   "/profile",
   "/new-post",
   "/edit-post",
+  "/new",
+  "/edit",
 ];
 
 const authRoutes = ["/login", "/register"];


### PR DESCRIPTION
### Updates to protected routes:
* Added `/new` and `/edit` to the list of protected routes in the `protectedRoutes` array.

### New redirection logic:
* Added a redirection for the `/auth` route: authenticated users are redirected to `/dashboard`, while unauthenticated users are redirected to `/login`.
* Added a redirection for `/users` and `/user` routes: authenticated users are redirected to their profile page (e.g., `/users/{userId}`), and unauthenticated users are redirected to `/login`.
* Added a redirection for `/blog`, `/blogs`, `/api`, and `/category` routes to the home page (`/`).