### PR TITLE
fix: Adjust search input margin left to keep alignment consistency

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -108,7 +108,7 @@ export default function Home() {
           <div className="lg:sticky lg:top-16 p-4 bg-background rounded-xl w-full ">
             <div>
               <div className="flex ml-auto flex-col gap-8">
-                <form className="ml-auto flex-1 sm:flex-start">
+                <form className="flex-1 sm:flex-start">
                   <div className="relative">
                     <Search className="absolute left-2.5 top-2.5 ml-2 h-5 w-4 text-muted-foreground" />
                     <Input


### PR DESCRIPTION
This pull request includes a small change to the `client/src/app/page.tsx` file. The change removes the `ml-auto` class from the `<form>` element within the `Home` component to adjust its alignment.