### PR TITLE
fix: remove deprecated react-quill dependency from package.json and p…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,6 @@
     "quill-image-resize-module-react": "^3.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-quill": "^2.0.0",
     "react-quill-new": "^3.4.6",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7"

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -86,9 +86,6 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
-      react-quill:
-        specifier: ^2.0.0
-        version: 2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-quill-new:
         specifier: ^3.4.6
         version: 3.4.6(quill-delta@5.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1112,9 +1109,6 @@ packages:
 
   '@types/node@20.17.24':
     resolution: {integrity: sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==}
-
-  '@types/quill@1.3.10':
-    resolution: {integrity: sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==}
 
   '@types/react-dom@19.1.5':
     resolution: {integrity: sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==}
@@ -2688,12 +2682,6 @@ packages:
       react: ^16 || ^17 || ^18 || ^19
       react-dom: ^16 || ^17 || ^18 || ^19
 
-  react-quill@2.0.0:
-    resolution: {integrity: sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==}
-    peerDependencies:
-      react: ^16 || ^17 || ^18
-      react-dom: ^16 || ^17 || ^18
-
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -4240,10 +4228,6 @@ snapshots:
   '@types/node@20.17.24':
     dependencies:
       undici-types: 6.19.8
-
-  '@types/quill@1.3.10':
-    dependencies:
-      parchment: 1.1.4
 
   '@types/react-dom@19.1.5(@types/react@19.1.6)':
     dependencies:
@@ -6022,14 +6006,6 @@ snapshots:
       lodash-es: 4.17.21
       quill: 2.0.3
       quill-delta: 5.1.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  react-quill@2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@types/quill': 1.3.10
-      lodash: 4.17.21
-      quill: 1.3.7
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 


### PR DESCRIPTION
### Dependency Updates:

* [`client/package.json`](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL38): Replaced `react-quill` with `react-quill-new` (v3.4.6) to use the newer version of the library. (`[client/package.jsonL38](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL38)`)

### Lockfile Cleanup:

* `client/pnpm-lock.yaml`:
  - Removed all references to `react-quill` (v2.0.0) and its dependencies, including `@types/quill` and `quill`. (`[[1]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91L89-L91)`, `[[2]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91L1116-L1118)`, `[[3]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91L2691-L2696)`, `[[4]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91L6028-L6035)`)
  - Cleaned up `snapshots` section by removing entries related to `react-quill` and its dependencies. (`[[1]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91L4244-L4247)`, `[[2]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91L6028-L6035)`)